### PR TITLE
PBJ-131 Refactor tiny A/B testing JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # tiny-ab
-A Tiny A/B Testing Plugin for Wordpress
+A Tiny A/B Testing Plugin for WordPress
 
 This tiny A/B testing plugin shows different versions of page 
 content to users based on the last character of their lti_context_id. 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This tiny A/B testing plugin shows different versions of page content to users based on the last character of their `lti_context_id`.
 
+The plugin requires a minimum of two pieces of content: one marked as the original and the other marked as the alternative (see Instructions below for more detail).
+
+- The **original content** will be shown to users without an `lti_context_id` _or_ when the last character of their `lti_context_id`:
+  - is an even number (`0`, `2`, `4`, `6`, `8`)
+  - does _not_ match `b`, `d` or `f`
+- The **alternative content** will be shown to users when the last character of their `lti_context_id`:
+  - is an odd number (`1`, `3`, `5`, `7`, `9`)
+  - matches `b`, `d` or `f`
+
+## ✍️ Instructions
+
 Put the two versions of content you want to test in elements with classes of `ab-test-original` and  `ab-test-alternative`, like so:
 
 ```
@@ -10,10 +21,12 @@ Put the two versions of content you want to test in elements with classes of `ab
 <p class="ab-test-alternative">This is the alternate version.</p>
 ```
 
-⚠️ This implementation of the plugin expects that the two elements will be next to each other and the original will be first. The code does _not_ care what element the classnames are placed on or if they match (i.e., one element can be a `p` and the other can be a `div` and all will work as expected).
+The classnames are not restricted to `p` elements and the HTML elements with these classnames do _not_ need to match (i.e., one element can be a `p` and the other can be a `div` and all will work as expected).
 
 Multiple page elements can be marked this way.
 
-Users with an `lti_context_id` whose last character is `1`, `3`, `5`, `7`, `9`, `b`, `d`, or `f` will see the alternate version. All other users (including those without an `lti_context_id`) will see the original version.
-
-This plugin only shows different content to users. It does not collect any data about user behavior. That is, this plugin depends on a separate method of collecting and comparing data about users' behavior in order to complete the A/B testing.
+## ⚠️ Limitations
+This implementation of the plugin:
+- Requires the two elements to be next to each other _and_ for the original to be first.
+- Only works on WordPress posts and pages (see [`is_single`](https://developer.wordpress.org/reference/functions/is_single/)).
+- Does not collect any data about user behavior and depends on a separate method of collecting and comparing data about users' behavior in order to complete the A/B testing

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# tiny-ab
-A Tiny A/B Testing Plugin for WordPress
+# Candela Tiny A/B Tester
 
-This tiny A/B testing plugin shows different versions of page 
-content to users based on the last character of their `lti_context_id`. 
+This tiny A/B testing plugin shows different versions of page content to users based on the last character of their `lti_context_id`.
 
-Put the two versions of content you want to test in elements with classes of 
-`ab-test-original` and  `ab-test-alternative`, like so: 
+Put the two versions of content you want to test in elements with classes of `ab-test-original` and  `ab-test-alternative`, like so:
 
 ```
 <p class="ab-test-original">This is the original version.</p>
@@ -13,13 +10,10 @@ Put the two versions of content you want to test in elements with classes of
 <p class="ab-test-alternative">This is the alternate version.</p>
 ```
 
+⚠️ This implementation of the plugin expects that the two elements will be next to each other and the original will be first. The code does _not_ care what element the classnames are placed on or if they match (i.e., one element can be a `p` and the other can be a `div` and all will work as expected).
+
 Multiple page elements can be marked this way.
 
-Users with an `lti_context_id` whose last character is `1`, `3`, `5`, `7`, `9`, 
-`b`, `d`, or `f` will see the alternate version. All other users (including
-those without an `lti_context_id`) will see the original version.
+Users with an `lti_context_id` whose last character is `1`, `3`, `5`, `7`, `9`, `b`, `d`, or `f` will see the alternate version. All other users (including those without an `lti_context_id`) will see the original version.
 
-This plugin only shows different content to users. It does not collect any data
-about user behavior. That is, this plugin depends on a separate method of 
-collecting and comparing data about users' behavior in order to complete the 
-A/B testing.
+This plugin only shows different content to users. It does not collect any data about user behavior. That is, this plugin depends on a separate method of collecting and comparing data about users' behavior in order to complete the A/B testing.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 A Tiny A/B Testing Plugin for WordPress
 
 This tiny A/B testing plugin shows different versions of page 
-content to users based on the last character of their lti_context_id. 
+content to users based on the last character of their `lti_context_id`. 
 
 Put the two versions of content you want to test in elements with classes of 
-"ab-test-original" and  "ab-test-alternative", like so: 
+`ab-test-original` and  `ab-test-alternative`, like so: 
 
-&lt;p class = "ab-test-original"&gt;This is the original version.&lt;/p&gt;
+```
+<p class="ab-test-original">This is the original version.</p>
 
-&lt;p class = "ab-test-alternative"&gt;This is the alterante version.&lt;/p&gt; 
+<p class="ab-test-alternative">This is the alternate version.</p>
+```
 
 Multiple page elements can be marked this way.
 
-Users with an lti_context_id whose last character is '1', '3', '5', '7', '9', 
-'b', 'd', or 'f' will see the alternate version. All other users (including
-those without an lti_context_id) will see the original version.
+Users with an `lti_context_id` whose last character is `1`, `3`, `5`, `7`, `9`, 
+`b`, `d`, or `f` will see the alternate version. All other users (including
+those without an `lti_context_id`) will see the original version.
 
 This plugin only shows different content to users. It does not collect any data
 about user behavior. That is, this plugin depends on a separate method of 

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -1,4 +1,4 @@
-let tinyABinit = () => {
+const tinyABinit = () => {
   const contentOriginal = document.getElementsByClassName('ab-test-original');
   const contentAlt = document.getElementsByClassName('ab-test-alternative');
   const urlParams = new URLSearchParams(window.location.search);
@@ -11,7 +11,7 @@ let tinyABinit = () => {
   }
 }
 
-let addCSS = () => {
+const addCSS = () => {
   const style = document.createElement('style');
   style.innerHTML = `
     .ab-test-original+.ab-test-alternative { display: none; }
@@ -19,7 +19,7 @@ let addCSS = () => {
   document.head.appendChild(style);
 }
 
-let runTinyAB = (contentOriginal, contentAlt, id) => {
+const runTinyAB = (contentOriginal, contentAlt, id) => {
   const lastChar = id.slice(-1);
   const altChars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
   const showAlt = altChars.includes(lastChar);

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -6,36 +6,18 @@ const tinyABinit = () => {
 
   if (testCriteria) {
     const id = urlParams.get('lti_context_id');
-    addCSS();
     runTinyAB(contentOriginal, contentAlt, id);
   }
 }
 
-const addCSS = () => {
-  const style = document.createElement('style');
-  style.innerHTML = `
-    .ab-test-original+.ab-test-alternative { display: none; }
-  `;
-  document.head.appendChild(style);
-}
+const removeElements = (group) => Array.from(group).forEach(element => element.remove());
 
 const runTinyAB = (contentOriginal, contentAlt, id) => {
   const lastChar = id.slice(-1);
   const altChars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
   const showAlt = altChars.includes(lastChar);
 
-  showAlt ? (
-    Array.from(contentOriginal).forEach(original => {
-      original.remove();
-    }),
-    Array.from(contentAlt).forEach(alt => {
-      alt.style.display = 'block';
-    })
-  ) : (
-    Array.from(contentAlt).forEach(alt => {
-      alt.remove();
-    })
-  );
+  showAlt ? removeElements(contentOriginal) : removeElements(contentAlt);
 }
 
 tinyABinit();

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -25,15 +25,15 @@ let runTinyAB = (contentOriginal, contentAlt, id) => {
   const showAlt = altChars.includes(lastChar);
 
   showAlt ? (
-    Array.from(contentAlt).forEach(alt => {
-      alt.remove();
-    })  
-  ) : (
     Array.from(contentOriginal).forEach(original => {
       original.remove();
     }),
     Array.from(contentAlt).forEach(alt => {
       alt.style.display = 'block';
+    })
+  ) : (
+    Array.from(contentAlt).forEach(alt => {
+      alt.remove();
     })
   );
 }

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -1,0 +1,41 @@
+let tinyABinit = () => {
+  const contentOriginal = document.getElementsByClassName('ab-test-original');
+  const contentAlt = document.getElementsByClassName('ab-test-alternative');
+  const urlParams = new URLSearchParams(window.location.search);
+  const testCriteria = (contentAlt.length > 0) && (urlParams.has('lti_context_id'));
+
+  if (testCriteria) {
+    const id = urlParams.get('lti_context_id');
+    addCSS();
+    runTinyAB(contentOriginal, contentAlt, id);
+  }
+}
+
+let addCSS = () => {
+  const style = document.createElement('style');
+  style.innerHTML = `
+    .ab-test-original+.ab-test-alternative { display: none; }
+  `;
+  document.head.appendChild(style);
+}
+
+let runTinyAB = (contentOriginal, contentAlt, id) => {
+  const lastChar = id.slice(-1);
+  const altChars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
+  const showAlt = altChars.includes(lastChar);
+
+  showAlt ? (
+    Array.from(contentAlt).forEach(alt => {
+      alt.remove();
+    })  
+  ) : (
+    Array.from(contentOriginal).forEach(original => {
+      original.remove();
+    }),
+    Array.from(contentAlt).forEach(alt => {
+      alt.style.display = 'block';
+    })
+  );
+}
+
+tinyABinit();

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -29,11 +29,11 @@ defined( 'ABSPATH' ) or die( 'For real, dude?' );
 
 function tinyab() { ?>
 
-<style type = "text/css">
+  <style>
     .ab-test-alternative { display: none; }
-</style>
+  </style>
 
-  <script type="text/javascript">
+  <script>
 
         window.onload = function(){
 

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -26,4 +26,9 @@ lti_context_id will see ab-test-original version.
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
-wp_enqueue_script( 'lumen-tinyab-js', plugins_url( 'tiny-ab.js', __FILE__ ), array(), '0.1.1', true );
+add_action('wp_enqueue_scripts', 'tiny_ab_enqueue');
+function tiny_ab_enqueue() {
+  if (is_single()) {
+    wp_enqueue_script( 'lumen-tinyab-js', plugins_url( 'tiny-ab.js', __FILE__ ), array(), '0.1.1', true );
+  }
+}

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * @author David Wiley <david@lumenlearning.com>
- * @package Tiny A/B Tester Plugin for Wordpress
+ * @package Tiny A/B Tester Plugin for WordPress
  */
 /*
-Plugin Name: Tiny A/B Tester Plugin for Wordpress
+Plugin Name: Tiny A/B Tester Plugin for WordPress
 Plugin URI: https://github.com/kalendar/tiny-ab/
-Description: A tiny A/B testing implementation for Wordpress. Shows different versions 
+Description: A tiny A/B testing implementation for WordPress. Shows different versions 
 of page content to users based on the last character of their username. Depends on 
 a separate method of collecting and comparing data about users' behavior in order 
 to complete the testing.

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -1,29 +1,25 @@
 <?php
 /**
- * @author David Wiley <david@lumenlearning.com>
- * @package Tiny A/B Tester Plugin for WordPress
- */
-/*
-Plugin Name: Tiny A/B Tester Plugin for WordPress
-Plugin URI: https://github.com/kalendar/tiny-ab/
-Description: A tiny A/B testing implementation for WordPress. Shows different versions 
+ * Plugin Name:       Tiny A/B Tester Plugin for WordPress
+ * GitHub Plugin URI: https://github.com/lumenlearning/candela-tiny-ab
+ * Description:       A tiny A/B testing implementation for WordPress. Shows different versions 
 of page content to users based on the last character of their username. Depends on 
 a separate method of collecting and comparing data about users' behavior in order 
 to complete the testing.
-Version: 0.1.0
-Author: David Wiley / Lumen Learning
-Author URI: https://lumenlearning.com/
-License: MIT
-Text Domain: tiny-ab
-*/
+ * Version:           0.1.1
+ * Author:            David Wiley / Lumen Learning
+ * Author URI:        http://lumenlearning.com
+ * License:           MIT
+ * Text Domain:       lumen
+ */
 
 /*
 HOW TO USE THIS PLUGIN. 
 Put the two versions of content you want
-to test in elements with classes of "ab-test-original" and 
-"ab-test-alternative", like so: 
-<p class = "ab-test-original">This is version A.</p> 
-<p class = "ab-test-alternative">This is version B.</p> 
+to test in elements with classes of 'ab-test-original' and 
+'ab-test-alternative', like so: 
+<p class="ab-test-original">This is version A.</p> 
+<p class="ab-test-alternative">This is version B.</p> 
 Users will see one version or the other depending on the last 
 character of their lti_user_context. Users without an 
 lti_context_id will see ab-test-original version.

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -1,16 +1,14 @@
 <?php
 /**
- * Plugin Name:       Tiny A/B Tester Plugin for WordPress
+ * Plugin Name:       Candela Tiny A/B Tester
  * GitHub Plugin URI: https://github.com/lumenlearning/candela-tiny-ab
- * Description:       A tiny A/B testing implementation for WordPress. Shows different versions 
-of page content to users based on the last character of their username. Depends on 
-a separate method of collecting and comparing data about users' behavior in order 
-to complete the testing.
- * Version:           0.1.1
+ * Description:       Shows different blocks of page content to users based on the last character
+ * of their username.
  * Author:            David Wiley / Lumen Learning
  * Author URI:        http://lumenlearning.com
- * License:           MIT
  * Text Domain:       lumen
+ * License:           MIT
+ * Version:           0.1.1
  */
 
 /*
@@ -25,79 +23,7 @@ character of their lti_user_context. Users without an
 lti_context_id will see ab-test-original version.
 */
 
-defined( 'ABSPATH' ) or die( 'For real, dude?' );
+// Exit if accessed directly
+defined( 'ABSPATH' ) || exit;
 
-function tinyab() { ?>
-
-  <style>
-    .ab-test-alternative { display: none; }
-  </style>
-
-  <script>
-
-        window.onload = function(){
-
-  /* Only proceed if our classes are in the page */
-  if (document.getElementsByClassName('ab-test-alternative').length > 0) {
-
-    /* Grab parameters from the URL */
-    var queryString = window.location.search;
-    var urlParams = new URLSearchParams(queryString);
-
-    /* Only proceed if there's an lti_context_id */
-    if (urlParams.has('lti_context_id')) {
-
-      /* Get the lti_context_id */
-      var id = urlParams.get('lti_context_id');
-
-      /* Select the last character from the lti_context_id. */
-      var last_char = id.slice(-1);
-
-      /* Only proceed if the last character indicates we should assign
-      this user to the alternative condition */
-      var alt_chars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
-      if (alt_chars.indexOf(last_char) !== -1) {
-
-      /* Hide the original version and show the alternative version. */
-          var to_hide = document.getElementsByClassName("ab-test-original");
-          var i;
-          for (i = 0; i < to_hide.length; i++) {
-              to_hide[i].remove();
-              }
-
-          var to_show = document.getElementsByClassName("ab-test-alternative");
-          var i;
-          for (i = 0; i < to_show.length; i++) {
-              to_show[i].style.display = 'block';
-              }
-
-      /* Testing last character */
-      }
-
-    /* Testing for lti_context_id */
-    }
-
-  /* Testing for our css class */
-}
-
-/* If the original content is still there, remove the alternative. */
-if (document.getElementsByClassName('ab-test-original').length > 0) {
-  var to_hide = document.getElementsByClassName("ab-test-alternative");
-  var i;
-  for (i = 0; i < to_hide.length; i++) {
-      to_hide[i].remove();
-      }
-}
-
-/* onload function */
-}
-
-</script>
-
-        
-<?php
-}
-
-/* Add the tiny-ab function to the wp_head hook so it ends up in the page header */
-
-add_action('wp_head', 'tinyab');
+wp_enqueue_script( 'lumen-tinyab-js', plugins_url( 'tiny-ab.js', __FILE__ ), array(), '0.1.1', true );

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -11,17 +11,7 @@
  * Version:           0.1.1
  */
 
-/*
-HOW TO USE THIS PLUGIN. 
-Put the two versions of content you want
-to test in elements with classes of 'ab-test-original' and 
-'ab-test-alternative', like so: 
-<p class="ab-test-original">This is version A.</p> 
-<p class="ab-test-alternative">This is version B.</p> 
-Users will see one version or the other depending on the last 
-character of their lti_user_context. Users without an 
-lti_context_id will see ab-test-original version.
-*/
+/* See README for instructions on how to create an A/B test. */
 
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
## Description
This PR updates the plugin in the following ways:
- to enqueue a separate JS file
- break out the script into smaller functions

### Motivation and Context
This work makes it possible for the Learning Team to easily add alternate, testable content into PBJ books.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/PBJ-131)

## How Has This Been Tested?
This has been tested locally, but without the benefit of being able to truly test the `urlParams` because my local dev lacks an `lti_context_id`.

I considered adding actual tests but the lift to get PHPUnit running felt like...a lot.

---

## ⚠️ Deployment instructions ⚠️
After this code is approved, a separate PR will need to be created to add this plugin to [PBJ](https://github.com/lumenlearning/pbj) and to activate the plugin on our sites.

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have requested a review from at least one other dev