### PR TITLE
PBJ-131 | Implement Tiny A/B plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,5 @@ Multiple page elements can be marked this way.
 
 ## ⚠️ Limitations
 This implementation of the plugin:
-- Requires the two elements to be next to each other _and_ for the original to be first.
 - Only works on WordPress posts and pages (see [`is_single`](https://developer.wordpress.org/reference/functions/is_single/)).
 - Does not collect any data about user behavior and depends on a separate method of collecting and comparing data about users' behavior in order to complete the A/B testing

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -3,11 +3,9 @@ const tinyABinit = () => {
   const contentAlt = document.getElementsByClassName('ab-test-alternative');
   const urlParams = new URLSearchParams(window.location.search);
   const testCriteria = (contentAlt.length > 0) && (urlParams.has('lti_context_id'));
+  const id = urlParams.get('lti_context_id');
 
-  if (testCriteria) {
-    const id = urlParams.get('lti_context_id');
-    runTinyAB(contentOriginal, contentAlt, id);
-  }
+  testCriteria ? runTinyAB(contentOriginal, contentAlt, id) : removeElements(contentAlt);
 }
 
 const removeElements = (group) => Array.from(group).forEach(element => element.remove());


### PR DESCRIPTION
Quick fix: If there is _no_ LTI Context ID, we still need to hide the alternative text. This is what the original CSS was attempting to handle, but we can do it with JS (which also makes one of the limitations described in the README unnecessary).