### PR TITLE
User usernames instead of LTI context IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Candela Tiny A/B Tester
 
-This tiny A/B testing plugin shows different versions of page content to users based on the last character of their Wordpress username (which in the Lumen PBJ case is the lti_user_id provided by the user's LMS).
+This tiny A/B testing plugin shows different versions of page content to users based on the last character of their Wordpress `username` (which in the Lumen PBJ case is the `lti_user_id` provided by the user's LMS). Because of the way the LMS generates a `lti_user_id`, the `username` should always end with a `0-9` or `a-f`.
 
 The plugin requires a minimum of two pieces of content: one marked as the original and the other marked as the alternative (see Instructions below for more detail).
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
-# tiny-ab
-A Tiny A/B Testing Plugin for Wordpress
+# Candela Tiny A/B Tester
 
-This tiny A/B testing plugin shows different versions of page 
-content to users based on the last character of their lti_context_id. 
+This tiny A/B testing plugin shows different versions of page content to users based on the last character of their `lti_context_id`.
 
-Put the two versions of content you want to test in elements with classes of 
-"ab-test-original" and  "ab-test-alternative", like so: 
+The plugin requires a minimum of two pieces of content: one marked as the original and the other marked as the alternative (see Instructions below for more detail).
 
-&lt;p class = "ab-test-original"&gt;This is the original version.&lt;/p&gt;
+- The **original content** will be shown to users without an `lti_context_id` _or_ when the last character of their `lti_context_id`:
+  - is an even number (`0`, `2`, `4`, `6`, `8`)
+  - does _not_ match `b`, `d` or `f`
+- The **alternative content** will be shown to users when the last character of their `lti_context_id`:
+  - is an odd number (`1`, `3`, `5`, `7`, `9`)
+  - matches `b`, `d` or `f`
 
-&lt;p class = "ab-test-alternative"&gt;This is the alterante version.&lt;/p&gt; 
+## ✍️ Instructions
+
+Put the two versions of content you want to test in elements with classes of `ab-test-original` and  `ab-test-alternative`, like so:
+
+```
+<p class="ab-test-original">This is the original version.</p>
+
+<p class="ab-test-alternative">This is the alternate version.</p>
+```
+
+The classnames are not restricted to `p` elements and the HTML elements with these classnames do _not_ need to match (i.e., one element can be a `p` and the other can be a `div` and all will work as expected).
 
 Multiple page elements can be marked this way.
 
-Users with an lti_context_id whose last character is '1', '3', '5', '7', '9', 
-'b', 'd', or 'f' will see the alternate version. All other users (including
-those without an lti_context_id) will see the original version.
-
-This plugin only shows different content to users. It does not collect any data
-about user behavior. That is, this plugin depends on a separate method of 
-collecting and comparing data about users' behavior in order to complete the 
-A/B testing.
+## ⚠️ Limitations
+This implementation of the plugin:
+- Only works on WordPress posts and pages (see [`is_single`](https://developer.wordpress.org/reference/functions/is_single/)).
+- Does not collect any data about user behavior and depends on a separate method of collecting and comparing data about users' behavior in order to complete the A/B testing

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Candela Tiny A/B Tester
 
-This tiny A/B testing plugin shows different versions of page content to users based on the last character of their `lti_context_id`.
+This tiny A/B testing plugin shows different versions of page content to users based on the last character of their Wordpress username (which in the Lumen PBJ case is the lti_user_id provided by the user's LMS).
 
 The plugin requires a minimum of two pieces of content: one marked as the original and the other marked as the alternative (see Instructions below for more detail).
 
-- The **original content** will be shown to users without an `lti_context_id` _or_ when the last character of their `lti_context_id`:
+- The **original content** will be shown to users who are not logged in _or_ when the last character of their `username`:
   - is an even number (`0`, `2`, `4`, `6`, `8`)
   - does _not_ match `b`, `d` or `f`
-- The **alternative content** will be shown to users when the last character of their `lti_context_id`:
+- The **alternative content** will be shown to users when the last character of their `username`:
   - is an odd number (`1`, `3`, `5`, `7`, `9`)
   - matches `b`, `d` or `f`
 
@@ -28,4 +28,4 @@ Multiple page elements can be marked this way.
 ## ⚠️ Limitations
 This implementation of the plugin:
 - Only works on WordPress posts and pages (see [`is_single`](https://developer.wordpress.org/reference/functions/is_single/)).
-- Does not collect any data about user behavior and depends on a separate method of collecting and comparing data about users' behavior in order to complete the A/B testing
+- Does not collect any data about user behavior and depends on a separate method of collecting and comparing data about users' behavior in order to complete the A/B testing.

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -1,21 +1,20 @@
 const tinyABinit = () => {
-  const contentOriginal = document.getElementsByClassName('ab-test-original');
-  const contentAlt = document.getElementsByClassName('ab-test-alternative');
-  const urlParams = new URLSearchParams(window.location.search);
-  const testCriteria = (contentAlt.length > 0) && (urlParams.has('lti_context_id'));
-  const id = urlParams.get('lti_context_id');
-
-  testCriteria ? runTinyAB(contentOriginal, contentAlt, id) : removeElements(contentAlt);
-}
-
-const removeElements = (group) => Array.from(group).forEach(element => element.remove());
-
-const runTinyAB = (contentOriginal, contentAlt, id) => {
-  const lastChar = id.slice(-1);
-  const altChars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
-  const showAlt = altChars.includes(lastChar);
-
-  showAlt ? removeElements(contentOriginal) : removeElements(contentAlt);
-}
-
-tinyABinit();
+    const contentOriginal = document.getElementsByClassName('ab-test-original');
+    const contentAlt = document.getElementsByClassName('ab-test-alternative');
+    const id = wp_user_info.username.data.display_name;
+    const testCriteria = (contentAlt.length > 0) && (typeof id !== 'undefined');
+  
+    testCriteria ? runTinyAB(contentOriginal, contentAlt, id) : removeElements(contentAlt);
+  }
+  
+  const removeElements = (group) => Array.from(group).forEach(element => element.remove());
+  
+  const runTinyAB = (contentOriginal, contentAlt, id) => {
+    const lastChar = id.slice(-1);
+    const altChars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
+    const showAlt = altChars.includes(lastChar);
+  
+    showAlt ? removeElements(contentOriginal) : removeElements(contentAlt);
+  }
+  
+  tinyABinit();

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -3,7 +3,7 @@ const tinyABinit = () => {
     const contentAlt = document.getElementsByClassName('ab-test-alternative');
     const id = wp_user_info.username.data.display_name;
     const testCriteria = (contentAlt.length > 0) && (typeof id !== 'undefined');
-    window.alert(id);
+    
     testCriteria ? runTinyAB(contentOriginal, contentAlt, id) : removeElements(contentAlt);
   }
 

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -1,0 +1,21 @@
+const tinyABinit = () => {
+  const contentOriginal = document.getElementsByClassName('ab-test-original');
+  const contentAlt = document.getElementsByClassName('ab-test-alternative');
+  const urlParams = new URLSearchParams(window.location.search);
+  const testCriteria = (contentAlt.length > 0) && (urlParams.has('lti_context_id'));
+  const id = urlParams.get('lti_context_id');
+
+  testCriteria ? runTinyAB(contentOriginal, contentAlt, id) : removeElements(contentAlt);
+}
+
+const removeElements = (group) => Array.from(group).forEach(element => element.remove());
+
+const runTinyAB = (contentOriginal, contentAlt, id) => {
+  const lastChar = id.slice(-1);
+  const altChars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
+  const showAlt = altChars.includes(lastChar);
+
+  showAlt ? removeElements(contentOriginal) : removeElements(contentAlt);
+}
+
+tinyABinit();

--- a/tiny-ab.js
+++ b/tiny-ab.js
@@ -3,18 +3,18 @@ const tinyABinit = () => {
     const contentAlt = document.getElementsByClassName('ab-test-alternative');
     const id = wp_user_info.username.data.display_name;
     const testCriteria = (contentAlt.length > 0) && (typeof id !== 'undefined');
-  
+    window.alert(id);
     testCriteria ? runTinyAB(contentOriginal, contentAlt, id) : removeElements(contentAlt);
   }
-  
+
   const removeElements = (group) => Array.from(group).forEach(element => element.remove());
-  
+
   const runTinyAB = (contentOriginal, contentAlt, id) => {
     const lastChar = id.slice(-1);
     const altChars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
     const showAlt = altChars.includes(lastChar);
-  
+
     showAlt ? removeElements(contentOriginal) : removeElements(contentAlt);
   }
-  
+
   tinyABinit();

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -2,8 +2,7 @@
 /**
  * Plugin Name:       Candela Tiny A/B Tester
  * GitHub Plugin URI: https://github.com/lumenlearning/candela-tiny-ab
- * Description:       Shows different blocks of page content to users based on the last character
- * of their username.
+ * Description:       Shows different blocks of page content to users based on the last character of their username.
  * Author:            David Wiley / Lumen Learning
  * Author URI:        http://lumenlearning.com
  * Text Domain:       lumen

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -1,107 +1,24 @@
 <?php
 /**
- * @author David Wiley <david@lumenlearning.com>
- * @package Tiny A/B Tester Plugin for Wordpress
+ * Plugin Name:       Candela Tiny A/B Tester
+ * GitHub Plugin URI: https://github.com/lumenlearning/candela-tiny-ab
+ * Description:       Shows different blocks of page content to users based on the last character
+ * of their username.
+ * Author:            David Wiley / Lumen Learning
+ * Author URI:        http://lumenlearning.com
+ * Text Domain:       lumen
+ * License:           MIT
+ * Version:           0.1.1
  */
-/*
-Plugin Name: Tiny A/B Tester Plugin for Wordpress
-Plugin URI: https://github.com/kalendar/tiny-ab/
-Description: A tiny A/B testing implementation for Wordpress. Shows different versions 
-of page content to users based on the last character of their username. Depends on 
-a separate method of collecting and comparing data about users' behavior in order 
-to complete the testing.
-Version: 0.1.0
-Author: David Wiley / Lumen Learning
-Author URI: https://lumenlearning.com/
-License: MIT
-Text Domain: tiny-ab
-*/
 
-/*
-HOW TO USE THIS PLUGIN. 
-Put the two versions of content you want
-to test in elements with classes of "ab-test-original" and 
-"ab-test-alternative", like so: 
-<p class = "ab-test-original">This is version A.</p> 
-<p class = "ab-test-alternative">This is version B.</p> 
-Users will see one version or the other depending on the last 
-character of their lti_user_context. Users without an 
-lti_context_id will see ab-test-original version.
-*/
+/* See README for instructions on how to create an A/B test. */
 
-defined( 'ABSPATH' ) or die( 'For real, dude?' );
+// Exit if accessed directly
+defined( 'ABSPATH' ) || exit;
 
-function tinyab() { ?>
-
-<style type = "text/css">
-    .ab-test-alternative { display: none; }
-</style>
-
-  <script type="text/javascript">
-
-        window.onload = function(){
-
-  /* Only proceed if our classes are in the page */
-  if (document.getElementsByClassName('ab-test-alternative').length > 0) {
-
-    /* Grab parameters from the URL */
-    var queryString = window.location.search;
-    var urlParams = new URLSearchParams(queryString);
-
-    /* Only proceed if there's an lti_context_id */
-    if (urlParams.has('lti_context_id')) {
-
-      /* Get the lti_context_id */
-      var id = urlParams.get('lti_context_id');
-
-      /* Select the last character from the lti_context_id. */
-      var last_char = id.slice(-1);
-
-      /* Only proceed if the last character indicates we should assign
-      this user to the alternative condition */
-      var alt_chars = ['1', '3', '5', '7', '9', 'b', 'd', 'f'];
-      if (alt_chars.indexOf(last_char) !== -1) {
-
-      /* Hide the original version and show the alternative version. */
-          var to_hide = document.getElementsByClassName("ab-test-original");
-          var i;
-          for (i = 0; i < to_hide.length; i++) {
-              to_hide[i].remove();
-              }
-
-          var to_show = document.getElementsByClassName("ab-test-alternative");
-          var i;
-          for (i = 0; i < to_show.length; i++) {
-              to_show[i].style.display = 'block';
-              }
-
-      /* Testing last character */
-      }
-
-    /* Testing for lti_context_id */
-    }
-
-  /* Testing for our css class */
+add_action('wp_enqueue_scripts', 'tiny_ab_enqueue');
+function tiny_ab_enqueue() {
+  if (is_single()) {
+    wp_enqueue_script( 'lumen-tinyab-js', plugins_url( 'tiny-ab.js', __FILE__ ), array(), '0.1.1', true );
+  }
 }
-
-/* If the original content is still there, remove the alternative. */
-if (document.getElementsByClassName('ab-test-original').length > 0) {
-  var to_hide = document.getElementsByClassName("ab-test-alternative");
-  var i;
-  for (i = 0; i < to_hide.length; i++) {
-      to_hide[i].remove();
-      }
-}
-
-/* onload function */
-}
-
-</script>
-
-        
-<?php
-}
-
-/* Add the tiny-ab function to the wp_head hook so it ends up in the page header */
-
-add_action('wp_head', 'tinyab');

--- a/tiny-ab.php
+++ b/tiny-ab.php
@@ -8,17 +8,23 @@
  * Author URI:        http://lumenlearning.com
  * Text Domain:       lumen
  * License:           MIT
- * Version:           0.1.1
+ * Version:           0.2.0
  */
 
 /* See README for instructions on how to create an A/B test. */
 
 // Exit if accessed directly
+
 defined( 'ABSPATH' ) || exit;
 
 add_action('wp_enqueue_scripts', 'tiny_ab_enqueue');
 function tiny_ab_enqueue() {
   if (is_single()) {
+    global $current_user;
+    $current_user = wp_get_current_user();
     wp_enqueue_script( 'lumen-tinyab-js', plugins_url( 'tiny-ab.js', __FILE__ ), array(), '0.1.1', true );
+    wp_localize_script( 'lumen-tinyab-js', 'wp_user_info', array (
+      'username' => $current_user,
+   ) );
   }
 }


### PR DESCRIPTION
This pulls in David Wiley's changes to display different content using usernames instead of LTI context IDs.